### PR TITLE
Update Stringy dependency to updated Voku repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.0.0",
-        "danielstjules/stringy": "~3.1.0",
+        "voku/stringy": "^5.1.0",
         "mofodojodino/profanity-filter": "^1.3",
         "tcb13/substringy": "^1.0",
         "davechild/textstatistics": "^1.0",


### PR DESCRIPTION
Fixes naming collision with Craft's included Stringy library (Issue [#25](https://github.com/TopShelfCraft/Wordsmith/issues/25))